### PR TITLE
Shininess now displays on the set recommendation screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ src/data/map_group_count.h
 pokeemerald_memorystats.csv
 data/maps/**/*.inc
 tools/poryscript/*
+.cache/*
+compile_commands.json
+.vscode/*
 tools/ups/*
 !tools/Pokabbie/Build
 pokeemerald-*.png

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -998,12 +998,13 @@
 	.endm
 
 	@ Displays a box containing the front sprite for the specified Pokemon species.
-	.macro showmonpic species:req, x:req, y:req, obscured=FALSE
+	.macro showmonpic species:req, x:req, y:req, obscured=FALSE, shiny=FALSE
 	.byte 0x75
 	.2byte \species
 	.byte \x
 	.byte \y
 	.byte \obscured
+	.2byte \shiny
 	.endm
 
 	@ Hides the box displayed by showmonpic.

--- a/data/maps/Rogue_Interior_School/scripts.pory
+++ b/data/maps/Rogue_Interior_School/scripts.pory
@@ -1,6 +1,9 @@
 mapscripts Rogue_Interior_School_MapScripts {}
 
 
+const VAR_PARTY_MON_SPECIES = VAR_TEMP_0
+const VAR_PARTY_MON_IS_SHINY = VAR_TEMP_1
+
 script Rogue_Interior_School_ShowSetRecommendation
 {
     lock
@@ -12,9 +15,10 @@ script Rogue_Interior_School_ShowSetRecommendation
 
     while(var(VAR_0x8004) != PARTY_SIZE)
     {
-        specialvar(VAR_RESULT, ScriptGetPartyMonSpecies)
-        showmonpic(VAR_RESULT, 2, 2)
-        playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+        specialvar(VAR_PARTY_MON_SPECIES, ScriptGetPartyMonSpecies)
+        specialvar(VAR_PARTY_MON_IS_SHINY, ScriptGetPartyMonIsShiny)
+        showmonpic(VAR_PARTY_MON_SPECIES, 2, 2, FALSE, VAR_PARTY_MON_IS_SHINY)
+        playmoncry(VAR_TEMP_0, CRY_MODE_NORMAL)
 
         callnative(ScriptMenu_DisplayRecommendedMonSet)
         messageinstant("{DPAD_LEFTRIGHT} Cycle Party Pokémon\n{A_BUTTON} {B_BUTTON} Exit")

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -532,6 +532,7 @@ gSpecials::
 	def_special SetRoute123Weather
 	def_special GetContestMultiplayerId
 	def_special ScriptGetPartyMonSpecies
+	def_special ScriptGetPartyMonIsShiny
 	def_special IsSelectedMonEgg
 	def_special TryInitBattleTowerAwardManObjectEvent
 	def_special MoveOutOfSecretBaseFromOutside

--- a/include/field_effect.h
+++ b/include/field_effect.h
@@ -52,7 +52,7 @@ void SpriteCB_AshLaunch(struct Sprite *);
 
 void MultiplyPaletteRGBComponents(u16 i, u8 r, u8 g, u8 b);
 void FreeResourcesAndDestroySprite(struct Sprite *sprite, u8 spriteId);
-u8 CreateMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority);
+u8 CreateMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority, bool8 isShiny);
 void StartEscapeRopeFieldEffect(void);
 
 #endif // GUARD_FIELD_EFFECTS_H

--- a/include/script_menu.h
+++ b/include/script_menu.h
@@ -12,7 +12,7 @@ bool8 ScriptMenu_MultichoiceWithDefault(u8 left, u8 top, u8 multichoiceId, bool8
 //void DrawMultichoiceMenuInternal(u8 left, u8 top, u8 multichoiceId, bool8 ignoreBPress, u8 cursorPos, const struct MenuAction *actions, int count);
 bool8 ScriptMenu_YesNo(u8 left, u8 top);
 bool8 ScriptMenu_MultichoiceGrid(u8 left, u8 top, u8 multichoiceId, bool8 ignoreBPress, u8 columnCount);
-bool8 ScriptMenu_ShowPokemonPic(u16 species, u8 x, u8 y, bool8 isObscured);
+bool8 ScriptMenu_ShowPokemonPic(u16 species, u8 x, u8 y, bool8 isObscured, bool8 isShiny);
 bool8 (*ScriptMenu_HidePokemonPic(void))(void);
 int ConvertPixelWidthToTileWidth(int width);
 u8 CreateWindowFromRect(u8 x, u8 y, u8 width, u8 height);

--- a/include/trainer_pokemon_sprites.h
+++ b/include/trainer_pokemon_sprites.h
@@ -9,7 +9,7 @@
 
 bool16 ResetAllPicSprites(void);
 u16 CreateMonPicSprite_Affine(u16 species, u32 otId, u32 personality, u8 gender, bool8 isShiny, u8 flags, s16 x, s16 y, u8 paletteSlot, u16 paletteTag);
-u16 CreateMonPicSprite(u16 species, u32 otId, u32 personality, u8 gender, bool8 isFrontPic, s16 x, s16 y, u8 paletteSlot, u16 paletteTag);
+u16 CreateMonPicSprite(u16 species, u32 otId, u32 personality, u8 gender, bool8 isShiny, bool8 isFrontPic, s16 x, s16 y, u8 paletteSlot, u16 paletteTag);
 u16 FreeAndDestroyMonPicSprite(u16 spriteId);
 u16 CreateTrainerPicSprite(u16 species, bool8 isFrontPic, s16 x, s16 y, u8 paletteSlot, u16 paletteTag);
 u16 FreeAndDestroyTrainerPicSprite(u16 spriteId);

--- a/src/battle_debug.c
+++ b/src/battle_debug.c
@@ -805,6 +805,7 @@ static void Task_ShowAiPoints(u8 taskId)
                                                  gBattleMons[data->aiBattlerId].otId,
                                                  gBattleMons[data->aiBattlerId].personality,
                                                  GetGenderForSpecies(gBattleMons[data->aiBattlerId].species, gBattleMons[data->aiBattlerId].genderFlag),
+                                                 FALSE,
                                                  TRUE,
                                                  39, 130, 15, TAG_NONE);
         data->aiViewState++;
@@ -964,6 +965,7 @@ static void Task_ShowAiKnowledge(u8 taskId)
                                                  gBattleMons[data->aiBattlerId].otId,
                                                  gBattleMons[data->aiBattlerId].personality,
                                                  GetGenderForSpecies(gBattleMons[data->aiBattlerId].species, gBattleMons[data->aiBattlerId].genderFlag),
+                                                 FALSE,
                                                  TRUE,
                                                  39, 130, 15, TAG_NONE);
         data->aiViewState++;

--- a/src/battle_factory_screen.c
+++ b/src/battle_factory_screen.c
@@ -2020,7 +2020,7 @@ static void Select_CreateMonSprite(void)
     u32 otId = GetMonData(mon, MON_DATA_OT_ID, NULL);
     u8 gender = GetMonGender(mon);
 
-    sFactorySelectScreen->monPics[1].monSpriteId = CreateMonPicSprite(species, otId, personality, gender, TRUE, 88, 32, 15, TAG_NONE);
+    sFactorySelectScreen->monPics[1].monSpriteId = CreateMonPicSprite(species, otId, personality, gender, FALSE, TRUE, 88, 32, 15, TAG_NONE);
     gSprites[sFactorySelectScreen->monPics[1].monSpriteId].centerToCornerVecX = 0;
     gSprites[sFactorySelectScreen->monPics[1].monSpriteId].centerToCornerVecY = 0;
 
@@ -2048,7 +2048,7 @@ static void Select_ReshowMonSprite(void)
     otId = GetMonData(mon, MON_DATA_OT_ID, NULL);
     gender = GetMonGender(mon);
 
-    sFactorySelectScreen->monPics[1].monSpriteId = CreateMonPicSprite(species, otId, personality, gender, TRUE, 88, 32, 15, TAG_NONE);
+    sFactorySelectScreen->monPics[1].monSpriteId = CreateMonPicSprite(species, otId, personality, gender, FALSE, TRUE, 88, 32, 15, TAG_NONE);
     gSprites[sFactorySelectScreen->monPics[1].monSpriteId].centerToCornerVecX = 0;
     gSprites[sFactorySelectScreen->monPics[1].monSpriteId].centerToCornerVecY = 0;
 
@@ -2071,7 +2071,7 @@ static void Select_CreateChosenMonsSprites(void)
                 u32 otId = GetMonData(mon, MON_DATA_OT_ID, NULL);
                 u8 gender = GetMonGender(mon);
 
-                sFactorySelectScreen->monPics[i].monSpriteId = CreateMonPicSprite(species, otId, personality, gender, TRUE, (i * 72) + 16, 32, i + 13, TAG_NONE);
+                sFactorySelectScreen->monPics[i].monSpriteId = CreateMonPicSprite(species, otId, personality, gender, FALSE, TRUE, (i * 72) + 16, 32, i + 13, TAG_NONE);
                 gSprites[sFactorySelectScreen->monPics[i].monSpriteId].centerToCornerVecX = 0;
                 gSprites[sFactorySelectScreen->monPics[i].monSpriteId].centerToCornerVecY = 0;
                 break;
@@ -4093,9 +4093,9 @@ static void Swap_ShowSummaryMonSprite(void)
     gender = GetMonGender(mon);
 
 #ifdef BUGFIX
-    sFactorySwapScreen->monPic.monSpriteId = CreateMonPicSprite(species, otId, personality, gender, TRUE, 88, 32, 15, TAG_NONE);
+    sFactorySwapScreen->monPic.monSpriteId = CreateMonPicSprite(species, otId, personality, gender, FALSE, TRUE, 88, 32, 15, TAG_NONE);
 #else
-    sFactorySwapScreen->monPic.monSpriteId = CreateMonPicSprite(species, personality, otId, gender, TRUE, 88, 32, 15, TAG_NONE);
+    sFactorySwapScreen->monPic.monSpriteId = CreateMonPicSprite(species, personality, otId, gender, FALSE, TRUE, 88, 32, 15, TAG_NONE);
 #endif
     gSprites[sFactorySwapScreen->monPic.monSpriteId].centerToCornerVecX = 0;
     gSprites[sFactorySwapScreen->monPic.monSpriteId].centerToCornerVecY = 0;
@@ -4314,7 +4314,7 @@ static void Swap_CreateMonSprite(void)
     otId = GetMonData(mon, MON_DATA_OT_ID, NULL);
     gender = GetMonGender(mon);
 
-    sFactorySwapScreen->monPic.monSpriteId = CreateMonPicSprite(species, otId, personality, gender, TRUE, 88, 32, 15, TAG_NONE);
+    sFactorySwapScreen->monPic.monSpriteId = CreateMonPicSprite(species, otId, personality, gender, FALSE, TRUE, 88, 32, 15, TAG_NONE);
     gSprites[sFactorySwapScreen->monPic.monSpriteId].centerToCornerVecX = 0;
     gSprites[sFactorySwapScreen->monPic.monSpriteId].centerToCornerVecY = 0;
 

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -1000,9 +1000,9 @@ u8 AddNewGameBirchObject(s16 x, s16 y, u8 subpriority)
     return CreateSprite(&sSpriteTemplate_NewGameBirch, x, y, subpriority);
 }
 
-u8 CreateMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority)
+u8 CreateMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority, bool8 isShiny)
 {
-    s32 spriteId = CreateMonPicSprite(species, 0, 0x8000, GetGenderForSpecies(species, 0), TRUE, x, y, 0, species);
+    s32 spriteId = CreateMonPicSprite(species, 0, 0x8000, GetGenderForSpecies(species, 0), isShiny, TRUE, x, y, 0, species);
     PreservePaletteInWeather(IndexOfSpritePaletteTag(species) + 0x10);
     if (spriteId == 0xFFFF)
         return MAX_SPRITES;
@@ -1013,7 +1013,7 @@ u8 CreateMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority)
 u8 CreateMonSprite_FieldMove(u16 species, u32 otId, u32 personality, u8 gender, s16 x, s16 y, u8 subpriority)
 {
     // TODO - Fixup shinyness
-    u16 spriteId = CreateMonPicSprite(species, otId, personality, gender, TRUE, x, y, 0, species);
+    u16 spriteId = CreateMonPicSprite(species, otId, personality, gender, FALSE, TRUE, x, y, 0, species);
     PreservePaletteInWeather(IndexOfSpritePaletteTag(species) + 0x10);
     if (spriteId == 0xFFFF)
         return MAX_SPRITES;

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -1,3 +1,4 @@
+#include "gba/isagbprint.h"
 #include "global.h"
 #include "debug.h"
 #include "malloc.h"
@@ -1578,6 +1579,11 @@ u8 GetLeadMonIndex(void)
 u16 ScriptGetPartyMonSpecies(void)
 {
     return GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_SPECIES_OR_EGG, NULL);
+}
+
+bool16 ScriptGetPartyMonIsShiny(void)
+{  
+    return GetMonData(&gPlayerParty[gSpecialVar_0x8004], MON_DATA_IS_SHINY, NULL);
 }
 
 // Removed for Emerald

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -3978,7 +3978,7 @@ static void Task_DisplayCaughtMonDexPage(u8 taskId)
         gTasks[taskId].tState++;
         break;
     case 4:
-        spriteId = CreateMonPicSprite(NationalPokedexNumToSpecies(dexNum), 0, ((u16)gTasks[taskId].tPersonalityHi << 16) | (u16)gTasks[taskId].tPersonalityLo, GetGenderForSpecies(NationalPokedexNumToSpecies(dexNum), 0), TRUE, MON_PAGE_X, MON_PAGE_Y, 0, TAG_NONE);
+        spriteId = CreateMonPicSprite(NationalPokedexNumToSpecies(dexNum), 0, ((u16)gTasks[taskId].tPersonalityHi << 16) | (u16)gTasks[taskId].tPersonalityLo, GetGenderForSpecies(NationalPokedexNumToSpecies(dexNum), 0), FALSE, TRUE, MON_PAGE_X, MON_PAGE_Y, 0, TAG_NONE);
         gSprites[spriteId].oam.priority = 0;
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0x10, 0, RGB_BLACK);
         SetVBlankCallback(gPokedexVBlankCB);

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -4733,7 +4733,7 @@ static u32 GetPokedexMonPersonality(u16 species)
 static u16 CreateMonSpriteFromNationalDexNumberHGSS(u16 nationalNum, s16 x, s16 y, u16 paletteSlot)
 {
     nationalNum = NationalPokedexNumToSpeciesHGSS(nationalNum);
-    return CreateMonPicSprite(nationalNum, SHINY_ODDS, GetPokedexMonPersonality(nationalNum), GetGenderForSpecies(NationalPokedexNumToSpecies(dexNum), 0), TRUE, x, y, paletteSlot, TAG_NONE);
+    return CreateMonPicSprite(nationalNum, SHINY_ODDS, GetPokedexMonPersonality(nationalNum), GetGenderForSpecies(NationalPokedexNumToSpecies(dexNum), 0), FALSE, TRUE, x, y, paletteSlot, TAG_NONE);
 }
 
 static u16 GetPokemonScaleFromNationalDexNumber(u16 nationalNum)

--- a/src/pokenav_ribbons_summary.c
+++ b/src/pokenav_ribbons_summary.c
@@ -4,6 +4,7 @@
 #include "graphics.h"
 #include "international_string_util.h"
 #include "palette.h"
+#include "pokemon.h"
 #include "pokenav.h"
 #include "sound.h"
 #include "sprite.h"
@@ -401,7 +402,7 @@ static void GetMonNicknameLevelGender(u8 *nick, u8 *level, u8 *gender)
     StringGet_Nickname(nick);
 }
 
-static void GetMonSpeciesPersonalityOtId(u16 *species, u32 *personality, u32 *otId, u8 *gender)
+static void GetMonSpeciesPersonalityOtId(u16 *species, u32 *personality, u32 *otId, u8 *gender, bool8 *isShiny)
 {
     struct Pokenav_RibbonsSummaryList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_RIBBONS_SUMMARY_LIST);
     struct PokenavMonList *mons = list->monList;
@@ -415,6 +416,7 @@ static void GetMonSpeciesPersonalityOtId(u16 *species, u32 *personality, u32 *ot
         *personality = GetMonData(mon, MON_DATA_PERSONALITY);
         *otId = GetMonData(mon, MON_DATA_OT_ID);
         *gender = GetMonGender(mon);
+        *isShiny = GetMonData(mon, MON_DATA_IS_SHINY);
     }
     else
     {
@@ -424,6 +426,7 @@ static void GetMonSpeciesPersonalityOtId(u16 *species, u32 *personality, u32 *ot
         *personality = GetBoxMonData(boxMon, MON_DATA_PERSONALITY);
         *otId = GetBoxMonData(boxMon, MON_DATA_OT_ID);
         *gender = GetBoxMonGender(boxMon);
+        *isShiny = GetBoxMonData(boxMon, MON_DATA_IS_SHINY);
     }
 }
 
@@ -945,8 +948,9 @@ static void ResetSpritesAndDrawMonFrontPic(struct Pokenav_RibbonsSummaryMenu *me
     u16 species;
     u32 personality, otId;
     u8 gender;
+    bool8 isShiny;
 
-    GetMonSpeciesPersonalityOtId(&species, &personality, &otId, &gender);
+    GetMonSpeciesPersonalityOtId(&species, &personality, &otId, &gender, &isShiny);
     ResetAllPicSprites();
     menu->monSpriteId = DrawRibbonsMonFrontPic(MON_SPRITE_X_ON, MON_SPRITE_Y);
     PokenavFillPalette(15, 0);
@@ -965,9 +969,10 @@ static u16 DrawRibbonsMonFrontPic(s32 x, s32 y)
     u16 species, spriteId;
     u32 personality, otId;
     u8 gender;
+    bool8 isShiny;
 
-    GetMonSpeciesPersonalityOtId(&species, &personality, &otId, &gender);
-    spriteId = CreateMonPicSprite(species, otId, personality, gender, TRUE, MON_SPRITE_X_ON, MON_SPRITE_Y, 15, TAG_NONE);
+    GetMonSpeciesPersonalityOtId(&species, &personality, &otId, &gender, &isShiny);
+    spriteId = CreateMonPicSprite(species, otId, personality, gender, isShiny, TRUE, MON_SPRITE_X_ON, MON_SPRITE_Y, 15, TAG_NONE);
     gSprites[spriteId].oam.priority = 0;
     return spriteId;
 }

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1,3 +1,4 @@
+#include "gba/isagbprint.h"
 #include "global.h"
 #include "frontier_util.h"
 #include "battle_setup.h"
@@ -1521,8 +1522,9 @@ bool8 ScrCmd_showmonpic(struct ScriptContext *ctx)
     u8 x = ScriptReadByte(ctx);
     u8 y = ScriptReadByte(ctx);
     bool8 isObscured = ScriptReadByte(ctx);
+    bool8 isShiny = VarGet(ScriptReadHalfword(ctx));
 
-    ScriptMenu_ShowPokemonPic(species, x, y, isObscured);
+    ScriptMenu_ShowPokemonPic(species, x, y, isObscured, isShiny);
     return FALSE;
 }
 

--- a/src/script_menu.c
+++ b/src/script_menu.c
@@ -617,7 +617,7 @@ static void Task_PokemonPicWindow(u8 taskId)
     }
 }
 
-bool8 ScriptMenu_ShowPokemonPic(u16 species, u8 x, u8 y, bool8 isObscured)
+bool8 ScriptMenu_ShowPokemonPic(u16 species, u8 x, u8 y, bool8 isObscured, bool8 isShiny)
 {
     u8 taskId;
     u8 spriteId;
@@ -628,7 +628,7 @@ bool8 ScriptMenu_ShowPokemonPic(u16 species, u8 x, u8 y, bool8 isObscured)
     }
     else
     {
-        spriteId = CreateMonSprite_PicBox(species, x * 8 + 40, y * 8 + 40, 0);
+        spriteId = CreateMonSprite_PicBox(species, x * 8 + 40, y * 8 + 40, 0, isShiny);
         taskId = CreateTask(Task_PokemonPicWindow, 0x50);
         gTasks[taskId].tWindowId = CreateWindowFromRect(x, y, 8, 8);
         gTasks[taskId].tState = 0;

--- a/src/trainer_pokemon_sprites.c
+++ b/src/trainer_pokemon_sprites.c
@@ -1,3 +1,4 @@
+#include "gba/isagbprint.h"
 #include "global.h"
 #include "sprite.h"
 #include "window.h"
@@ -59,7 +60,7 @@ bool16 ResetAllPicSprites(void)
     return FALSE;
 }
 
-static bool16 DecompressPic(u16 species, u32 personality,  u8 gender, bool8 isFrontPic, u8 *dest, bool8 isTrainer)
+static bool16 DecompressPic(u16 species, u32 personality, u8 gender, bool8 isShiny, bool8 isFrontPic, u8 *dest, bool8 isTrainer)
 {
     if (!isTrainer)
     {
@@ -122,10 +123,10 @@ static void LoadPicPaletteByTagOrSlot(u16 species, u32 otId, u32 personality, u8
     }
 }
 
-static void LoadPicPaletteBySlot(u16 species, u32 otId, u32 personality, u8 gender, u8 paletteSlot, bool8 isTrainer)
+static void LoadPicPaletteBySlot(u16 species, u32 otId, u32 personality, u8 gender, bool8 isShiny, u8 paletteSlot, bool8 isTrainer)
 {
     if (!isTrainer)
-        LoadCompressedPalette(GetMonSpritePalFromSpecies(species, gender, FALSE), PLTT_ID(paletteSlot), PLTT_SIZE_4BPP);
+        LoadCompressedPalette(GetMonSpritePalFromSpecies(species, gender, isShiny), PLTT_ID(paletteSlot), PLTT_SIZE_4BPP);
     else
         LoadCompressedPalette(gTrainerFrontPicPaletteTable[species].data, PLTT_ID(paletteSlot), PLTT_SIZE_4BPP);
 }
@@ -138,7 +139,7 @@ static void AssignSpriteAnimsTable(bool8 isTrainer)
         sCreatingSpriteTemplate.anims = gTrainerFrontAnimsPtrTable[0];
 }
 
-static u16 CreatePicSprite(u16 species, u32 otId, u32 personality, u8 gender, bool8 isFrontPic, s16 x, s16 y, u8 paletteSlot, u16 paletteTag, bool8 isTrainer)
+static u16 CreatePicSprite(u16 species, u32 otId, u32 personality, u8 gender, bool8 isShiny, bool8 isFrontPic, s16 x, s16 y, u8 paletteSlot, u16 paletteTag, bool8 isTrainer)
 {
     u8 i;
     u8 *framePics;
@@ -164,7 +165,7 @@ static u16 CreatePicSprite(u16 species, u32 otId, u32 personality, u8 gender, bo
         Free(framePics);
         return 0xFFFF;
     }
-    if (DecompressPic(species, personality, gender, isFrontPic, framePics, isTrainer))
+    if (DecompressPic(species, personality, gender, isShiny, isFrontPic, framePics, isTrainer))
     {
         // debug trap?
         return 0xFFFF;
@@ -180,7 +181,7 @@ static u16 CreatePicSprite(u16 species, u32 otId, u32 personality, u8 gender, bo
     sCreatingSpriteTemplate.images = images;
     sCreatingSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
     sCreatingSpriteTemplate.callback = DummyPicSpriteCallback;
-    LoadPicPaletteByTagOrSlot(species, otId, personality, gender, FALSE, paletteSlot, paletteTag, isTrainer);
+    LoadPicPaletteByTagOrSlot(species, otId, personality, gender, isShiny, paletteSlot, paletteTag, isTrainer);
     spriteId = CreateSprite(&sCreatingSpriteTemplate, x, y, 0);
     if (paletteTag == TAG_NONE)
         gSprites[spriteId].oam.paletteNum = paletteSlot;
@@ -229,7 +230,7 @@ u16 CreateMonPicSprite_Affine(u16 species, u32 otId, u32 personality, u8 gender,
         Free(framePics);
         return 0xFFFF;
     }
-    if (DecompressPic(species, personality, gender, flags, framePics, FALSE))
+    if (DecompressPic(species, personality, gender, isShiny, flags, framePics, FALSE))
     {
         // debug trap?
         return 0xFFFF;
@@ -295,33 +296,33 @@ static u16 FreeAndDestroyPicSpriteInternal(u16 spriteId)
     return 0;
 }
 
-static u16 LoadPicSpriteInWindow(u16 species, u32 otId, u32 personality, u8 gender, bool8 isFrontPic, u8 paletteSlot, u8 windowId, bool8 isTrainer)
+static u16 LoadPicSpriteInWindow(u16 species, u32 otId, u32 personality, u8 gender, bool8 isShiny, bool8 isFrontPic, u8 paletteSlot, u8 windowId, bool8 isTrainer)
 {
-    if (DecompressPic(species, personality, gender, isFrontPic, (u8 *)GetWindowAttribute(windowId, WINDOW_TILE_DATA), FALSE))
+    if (DecompressPic(species, personality, gender, isShiny, isFrontPic, (u8 *)GetWindowAttribute(windowId, WINDOW_TILE_DATA), FALSE))
         return 0xFFFF;
 
-    LoadPicPaletteBySlot(species, otId, personality, gender, paletteSlot, isTrainer);
+    LoadPicPaletteBySlot(species, otId, personality, gender, isShiny, paletteSlot, isTrainer);
     return 0;
 }
 
-static u16 CreateTrainerCardSprite(u16 species, u32 otId, u32 personality, u8 gender, bool8 isFrontPic, u16 destX, u16 destY, u8 paletteSlot, u8 windowId, bool8 isTrainer)
+static u16 CreateTrainerCardSprite(u16 species, u32 otId, u32 personality, u8 gender, bool8 isShiny, bool8 isFrontPic, u16 destX, u16 destY, u8 paletteSlot, u8 windowId, bool8 isTrainer)
 {
     u8 *framePics;
 
     framePics = Alloc(TRAINER_PIC_SIZE * MAX_TRAINER_PIC_FRAMES);
-    if (framePics && !DecompressPic(species, personality, gender, isFrontPic, framePics, isTrainer))
+    if (framePics && !DecompressPic(species, personality, gender, isShiny, isFrontPic, framePics, isTrainer))
     {
         BlitBitmapRectToWindow(windowId, framePics, 0, 0, TRAINER_PIC_WIDTH, TRAINER_PIC_HEIGHT, destX, destY, TRAINER_PIC_WIDTH, TRAINER_PIC_HEIGHT);
-        LoadPicPaletteBySlot(species, otId, personality, gender, paletteSlot, isTrainer);
+        LoadPicPaletteBySlot(species, otId, personality, gender, isShiny, paletteSlot, isTrainer);
         Free(framePics);
         return 0;
     }
     return 0xFFFF;
 }
 
-u16 CreateMonPicSprite(u16 species, u32 otId, u32 personality, u8 gender, bool8 isFrontPic, s16 x, s16 y, u8 paletteSlot, u16 paletteTag)
+u16 CreateMonPicSprite(u16 species, u32 otId, u32 personality, u8 gender, bool8 isShiny, bool8 isFrontPic, s16 x, s16 y, u8 paletteSlot, u16 paletteTag)
 {
-    return CreatePicSprite(species, otId, personality, gender, isFrontPic, x, y, paletteSlot, paletteTag, FALSE);
+    return CreatePicSprite(species, otId, personality, gender, isShiny, isFrontPic, x, y, paletteSlot, paletteTag, FALSE);
 }
 
 u16 FreeAndDestroyMonPicSprite(u16 spriteId)
@@ -331,12 +332,12 @@ u16 FreeAndDestroyMonPicSprite(u16 spriteId)
 
 static u16 UNUSED LoadMonPicInWindow(u16 species, u32 otId, u32 personality, bool8 isFrontPic, u8 paletteSlot, u8 windowId)
 {
-    return LoadPicSpriteInWindow(species, otId, personality, 0, isFrontPic, paletteSlot, windowId, FALSE);
+    return LoadPicSpriteInWindow(species, otId, personality, 0, FALSE, isFrontPic, paletteSlot, windowId, FALSE);
 }
 
 u16 CreateTrainerPicSprite(u16 species, bool8 isFrontPic, s16 x, s16 y, u8 paletteSlot, u16 paletteTag)
 {
-    return CreatePicSprite(species, 0, 0, 0, isFrontPic, x, y, paletteSlot, paletteTag, TRUE);
+    return CreatePicSprite(species, 0, 0, 0, FALSE, isFrontPic, x, y, paletteSlot, paletteTag, TRUE);
 }
 
 u16 FreeAndDestroyTrainerPicSprite(u16 spriteId)
@@ -346,10 +347,10 @@ u16 FreeAndDestroyTrainerPicSprite(u16 spriteId)
 
 static u16 UNUSED LoadTrainerPicInWindow(u16 species, bool8 isFrontPic, u8 paletteSlot, u8 windowId)
 {
-    return LoadPicSpriteInWindow(species, 0, 0, 0, isFrontPic, paletteSlot, windowId, TRUE);
+    return LoadPicSpriteInWindow(species, 0, 0, 0, FALSE, isFrontPic, paletteSlot, windowId, TRUE);
 }
 
 u16 CreateTrainerCardTrainerPicSprite(u16 species, bool8 isFrontPic, u16 destX, u16 destY, u8 paletteSlot, u8 windowId)
 {
-    return CreateTrainerCardSprite(species, 0, 0, 0, isFrontPic, destX, destY, paletteSlot, windowId, TRUE);
+    return CreateTrainerCardSprite(species, 0, 0, 0, FALSE, isFrontPic, destX, destY, paletteSlot, windowId, TRUE);
 }


### PR DESCRIPTION
On the set recommendation screen, the Pokemon shown will now be shiny if the corresponding party mon is shiny. I dunno what's the preferred etiquette for doing PRs as it doesn't look like there's been a lot, but I figured this might be a nice feature to pass along if you'd like.

https://github.com/user-attachments/assets/de9f2198-53f7-491b-8b26-07a76ddc89ef
