### PR TITLE
Fix build on macOS (Apple Silicon)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ endif
 
 ifeq ($(OS),Windows_NT)
 PORYSCRIPT := tools/poryscript/poryscript-windows/poryscript$(EXE)
+else ifeq ($(shell uname -s),Darwin)
+PORYSCRIPT := tools/poryscript/poryscript-mac/poryscript$(EXE)
 else
 PORYSCRIPT := tools/poryscript/poryscript-linux/poryscript$(EXE)
 endif

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -33,7 +33,7 @@
 #include "frontier_util.h"
 #include "pokedex.h"
 #include "save.h"
-#include "string.h"
+#include <string.h>
 #include "strings.h"
 #include "string_util.h"
 #include "link_rfu.h"

--- a/src/rogue_debug.c
+++ b/src/rogue_debug.c
@@ -4,7 +4,7 @@
 #include "main.h"
 #include "malloc.h"
 #include "sound.h"
-#include "string.h"
+#include <string.h>
 #include "string_util.h"
 
 #include "rogue_baked.h"

--- a/src/rogue_multiplayer.c
+++ b/src/rogue_multiplayer.c
@@ -9,7 +9,7 @@
 #include "follow_me.h"
 #include "random.h"
 #include "script.h"
-#include "string.h"
+#include <string.h>
 #include "string_util.h"
 #include "task.h"
 

--- a/tools/Pokabbie/Build/CustomJson/QuestExporter.cpp
+++ b/tools/Pokabbie/Build/CustomJson/QuestExporter.cpp
@@ -755,7 +755,10 @@ void ExportQuestData_Pory(std::ofstream& fileStream, std::string const& dataPath
 		auto const& quest = *it;
 
 		fileStream << "text gQuestDescText_" << quest.GetUniqueWriteId() << "\n{\n";
-		fileStream << c_TabSpacing << "format(\"" << GetQuestDescription(quest) << "\")\n";
+		std::string questDesc = GetQuestDescription(quest);
+		strutil::replace_all(questDesc, "\r\n", "\\n");
+		strutil::replace_all(questDesc, "\n", "\\n");
+		fileStream << c_TabSpacing << "format(\"" << questDesc << "\")\n";
 		fileStream << "}\n\n";
 	}
 }


### PR DESCRIPTION
Building on macOS currently stops before producing a ROM. This fixes the three issues I hit, each one independent and small.

### 1. Quoted system header breaks dependency scanning

`src/new_game.c`, `src/rogue_debug.c` and `src/rogue_multiplayer.c` use `#include "string.h"`. The quoted form makes the dependency scanner treat it as a project-local header, so make demands a `src/string.h` that does not exist:

```
make: *** No rule to make target `src/string.h', needed by `build/modern_debug/src/new_game.o'.  Stop.
```

The compiler would fall through to the system header, but make aborts first. These includes are also redundant, since `global.h` already pulls in `<string.h>`.

### 2. Makefile has no macOS branch for poryscript

The Makefile splits only between Windows and everything else, and that else hardcodes `poryscript-linux`:

```
/bin/bash: tools/poryscript/poryscript-linux/poryscript: No such file or directory
```

poryscript already publishes a `poryscript-mac` archive alongside `poryscript-linux` and `poryscript-windows`, so the added branch follows the existing upstream naming. Linux and Windows paths are untouched.

### 3. Quest descriptions with newlines produce invalid poryscript

`QuestExporter.cpp` writes the raw JSON description inside `format("...")`. Any description containing a newline becomes a multi-line string literal, which poryscript rejects:

```
PORYSCRIPT ERROR: line 98: auto strings cannot be used with format()
```

This triggers on the shiny collector quest in `default_quests.json`, whose description contains `\n\n`. Escaping the newlines before emitting keeps the intended in-game line breaks while producing a single-line literal.

---

### How this was verified

Built the `EX-v2.1` tag on macOS 15 (Apple Silicon) with the Arm GNU Toolchain 13.2.1 and poryscript 3.6.0. With these three changes `make modern` completes and produces a 32 MB ROM that boots. Without them it stops at the errors quoted above.

### What I could not verify

- I did not build on Linux or Windows. The Makefile branch is gated on `Darwin` and the include change is platform-neutral, so neither should affect those, but I have not run it.
- I did not compare the rendered quest text in-game before and after the escaping change. `format("a\nb")` and a literal multi-line string should produce the same line break, but confirmation from someone who can diff the text box would be welcome.

### One open question

I would expect issues 1 and 3 to break the build on Linux too, since neither looks platform-specific. If your build works there, I am probably missing a step in the intended toolchain setup, and issue 2 may be the only genuinely macOS-specific item. Happy to split this into separate PRs or drop any part of it.